### PR TITLE
Fix wrong parameter types on 2 patches

### DIFF
--- a/StressandTaxes/Debt/DayLabel_Patch.cs
+++ b/StressandTaxes/Debt/DayLabel_Patch.cs
@@ -3,12 +3,9 @@ using HarmonyLib;
 
 namespace StressandTaxes.Debt.Patches
 {
-	// Token: 0x02000004 RID: 4
 	[HarmonyPatch(typeof(DayLabel), "Update")]
 	public static class DayLabel_Update_Patch
 	{
-		// Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
-
 		[HarmonyPrefix]
 		static void Prefix(DayLabel __instance)
 		{

--- a/StressandTaxes/Monsters/DSLittleMonster_Patch.cs
+++ b/StressandTaxes/Monsters/DSLittleMonster_Patch.cs
@@ -3,11 +3,9 @@ using HarmonyLib;
 
 namespace StressandTaxes.Monsters.Patches
 {
-	// Token: 0x02000004 RID: 4
 	[HarmonyPatch(typeof(DSLittleMonster), "CheckHomeDistance")]
 	public static class DSLittleMonster_CheckHomeDistance_Patch1
 	{
-		// Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
 		[HarmonyPrefix]
 		static void Prefix(DSLittleMonster __instance, ref float __state)
 		{
@@ -26,7 +24,6 @@ namespace StressandTaxes.Monsters.Patches
 	[HarmonyPatch(typeof(DSLittleMonster), "Move")]
 	public static class DSLittleMonster_Move_Patch
 	{
-		// Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
 		[HarmonyPrefix]
 		static void Prefix(DSLittleMonster __instance, ref float __state)
 		{
@@ -48,7 +45,6 @@ namespace StressandTaxes.Monsters.Patches
 	[HarmonyPatch(typeof(DSLittleMonster), "UpdateAttachment")]
 	public static class DSLittleMonster_UpdateAttachment_Patch
 	{
-		// Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
 		[HarmonyPrefix]
 		static void Prefix(DSLittleMonster __instance, ref float __state)
 		{
@@ -67,7 +63,6 @@ namespace StressandTaxes.Monsters.Patches
 	[HarmonyPatch(typeof(DSLittleMonster), "LookForPlayer")]
 	public static class DSLittleMonster_LookForPlayer_Patch
 	{
-		// Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
 		[HarmonyPrefix]
 		static void Prefix(DSLittleMonster __instance, ref float __state)
 		{

--- a/StressandTaxes/Monsters/DSLittleMonster_Patch.cs
+++ b/StressandTaxes/Monsters/DSLittleMonster_Patch.cs
@@ -1,4 +1,4 @@
-using System;
+using Winch.Core;
 using HarmonyLib;
 
 namespace StressandTaxes.Monsters.Patches
@@ -30,7 +30,7 @@ namespace StressandTaxes.Monsters.Patches
 			__state = __instance.speed;
 			__instance.speed *= (float)1.75 - (GameManager.Instance.Player.Sanity.CurrentSanity);
 			float sanity = GameManager.Instance.Player.Sanity.CurrentSanity;
-			FileLog.Log(sanity.ToString());
+			WinchCore.Log.Info("sanity: " + sanity.ToString());
 			
 		}
 

--- a/StressandTaxes/Monsters/MarrowMonster.cs
+++ b/StressandTaxes/Monsters/MarrowMonster.cs
@@ -3,12 +3,9 @@ using HarmonyLib;
 
 namespace StressandTaxes.Monsters.Patches
 {
-	// Token: 0x02000004 RID: 4
 	[HarmonyPatch(typeof(MarrowMonster), "Update")]
 	public static class MarrowMonster_Update_Patch
 	{
-		// Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
-
 		[HarmonyPostfix]
 		static void Postfix(MarrowMonster __instance)
 		{

--- a/StressandTaxes/Monsters/SBMonster_Patch.cs
+++ b/StressandTaxes/Monsters/SBMonster_Patch.cs
@@ -3,11 +3,9 @@ using HarmonyLib;
 
 namespace StressandTaxes.Monsters.Patches
 {
-	// Token: 0x02000004 RID: 4
 	[HarmonyPatch(typeof(SBMonsterAnimationHelper), "Update")]
 	public static class SBMonsterAnimationHelper_Patch
 	{
-		// Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
 		[HarmonyPrefix]
 		static void Prefix(SBMonsterAnimationHelper __instance, ref float __state)
 		{

--- a/StressandTaxes/Prices/Config_Patch.cs
+++ b/StressandTaxes/Prices/Config_Patch.cs
@@ -3,11 +3,9 @@ using HarmonyLib;
 
 namespace StressandTaxes.Costs.Patches
 {
-	// Token: 0x02000004 RID: 4
 	[HarmonyPatch(typeof(GameConfigData), "HullRepairCostPerSquare", MethodType.Getter)]
 	public static class GameConfigData_HullRepair_Patch
 	{
-		// Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
 		[HarmonyPostfix]
 		static void HullRepairCostPerSquare(ref decimal __result)
 		{
@@ -18,7 +16,6 @@ namespace StressandTaxes.Costs.Patches
     [HarmonyPatch(typeof(GameConfigData), "NightSanityModifier", MethodType.Getter)]
     public static class GameConfigData_SanityModifier_Patch
     {
-        // Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
         [HarmonyPostfix]
         static void NightSanityModifier(ref decimal __result)
         {
@@ -29,7 +26,6 @@ namespace StressandTaxes.Costs.Patches
     [HarmonyPatch(typeof(GameConfigData), "GreaterMarrowDebtRepaymentProportion", MethodType.Getter)]
     public static class GameConfigData_GreaterMarrowDebtRepaymentProportion_Patch
     {
-        // Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
         [HarmonyPostfix]
         static void GreaterMarrowDebtRepaymentProportion(ref decimal __result)
         {

--- a/StressandTaxes/Prices/Config_Patch.cs
+++ b/StressandTaxes/Prices/Config_Patch.cs
@@ -17,7 +17,7 @@ namespace StressandTaxes.Costs.Patches
     public static class GameConfigData_SanityModifier_Patch
     {
         [HarmonyPostfix]
-        static void NightSanityModifier(ref decimal __result)
+        static void NightSanityModifier(ref float __result)
         {
             __result *= 2;
         }

--- a/StressandTaxes/Prices/Sell_Patch.cs
+++ b/StressandTaxes/Prices/Sell_Patch.cs
@@ -3,11 +3,9 @@ using HarmonyLib;
 	
 namespace StressandTaxes.Costs.Patches
 {
-	// Token: 0x02000004 RID: 4
 	[HarmonyPatch(typeof(ItemManager), "GetItemValue")]
 	public static class ItemManager_Patch
 	{
-		// Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
 		[HarmonyPostfix]
 		public static void GetItemValue(ref decimal __result, SpatialItemInstance itemInstance, ItemManager.BuySellMode mode, float sellValueModifier = 0.5f)
 		{

--- a/StressandTaxes/Sanity/PlayerSanity_Patch.cs
+++ b/StressandTaxes/Sanity/PlayerSanity_Patch.cs
@@ -5,11 +5,9 @@ using static GameManager;
 
 namespace StressandTaxes.Sanity.Patches
 {
-    // Token: 0x02000004 RID: 4
     [HarmonyPatch(typeof(PlayerSanity), "Update")]
     public static class PlayerSanity_Update_Patch
     {
-        // Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
 
         [HarmonyPrefix]
         static void Prefix(PlayerSanity __instance)
@@ -24,7 +22,6 @@ namespace StressandTaxes.Sanity.Patches
     [HarmonyPatch(typeof(PlayerSanity), "ChangeSanity")]
     public static class PlayerSanity_ChangeSanity_Patch
     {
-        // Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
 
         [HarmonyPrefix]
         static void Prefix(PlayerSanity __instance)

--- a/StressandTaxes/Sanity/SanityModifier_Patch.cs
+++ b/StressandTaxes/Sanity/SanityModifier_Patch.cs
@@ -9,7 +9,7 @@ namespace StressandTaxes.Sanity.Patches
     public static class SanityModifierDetector_GetTotalModifierValue_Patch
     {
         [HarmonyPrefix]
-        static void Postfix(ref decimal __result)
+        static void Postfix(ref float __result)
         {
              __result *=  1;
         }

--- a/StressandTaxes/Sanity/SanityModifier_Patch.cs
+++ b/StressandTaxes/Sanity/SanityModifier_Patch.cs
@@ -5,12 +5,9 @@ using static GameManager;
 
 namespace StressandTaxes.Sanity.Patches
 {
-    // Token: 0x02000004 RID: 4
     [HarmonyPatch(typeof(SanityModifierDetector), "GetTotalModifierValue")]
     public static class SanityModifierDetector_GetTotalModifierValue_Patch
     {
-        // Token: 0x06000007 RID: 7 RVA: 0x00002C74 File Offset: 0x00000E74
-
         [HarmonyPrefix]
         static void Postfix(ref decimal __result)
         {


### PR DESCRIPTION
Fixes wrong parameter types on GameConfigData_SanityModifier_Patch.NightSanityModifier and SanityModifierDetector_GetTotalModifierValue_Patch.Postfix

also removes some dnspy comments that absolutely do not need to be there lol